### PR TITLE
Move index to root for browser hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 https://thgzzs.github.io/gpt-environment/
 
-This project demonstrates a minimal first‑person environment rendered on a canvas. Terrain and sky are generated procedurally using JavaScript modules in `src/` while static assets such as HTML live in the `public/` folder.
+This project demonstrates a minimal first‑person environment rendered on a canvas. Terrain and sky are generated procedurally using JavaScript modules in `src/`. The entry HTML file now lives in the project root so it can be served directly.
 
 ## Running the Demo
 
-Serve `public/index.html` with any static server. For example using the development server from the included `package.json`:
+Serve `index.html` with any static server. For example using the development server from the included `package.json`:
 
 ```bash
 npm install

--- a/index.html
+++ b/index.html
@@ -15,6 +15,6 @@
   </head>
   <body>
     <canvas id="canvas"></canvas>
-    <script type="module" src="../src/main.js"></script>
+    <script type="module" src="./src/main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- move `index.html` to project root
- remove now-empty public directory and update script path
- document new location in README

## Testing
- `npm run lint`
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684570dd7ae4832797f629c25c97b6ef