### PR TITLE
Fix cloud orientation and lighting

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -32,7 +32,8 @@ function loop() {
   updateCamera(terrain.getTerrainHeight);
 
   sky.render(ctx, time);
-  terrain.draw(ctx, camera);
+  const dayFactor = sky.getDayFactor(time);
+  terrain.draw(ctx, camera, dayFactor);
 
   requestAnimationFrame(loop);
 }

--- a/src/sky.js
+++ b/src/sky.js
@@ -19,6 +19,12 @@ export function createSky(camera) {
   const perspectiveExponent = 0.45;
   const dayCyclePeriod = 60;
 
+  function getDayFactor(time) {
+    return (
+      0.5 + 0.5 * Math.sin((2 * Math.PI * time) / dayCyclePeriod - Math.PI / 2)
+    );
+  }
+
   const daySkyTop = { r: 120, g: 180, b: 240 };
   const daySkyBottom = { r: 165, g: 200, b: 255 };
   const nightSkyTop = { r: 0, g: 0, b: 20 };
@@ -79,8 +85,7 @@ export function createSky(camera) {
   function render(ctx, time) {
     const wOff = offCanvas.width,
       hOff = offCanvas.height;
-    const dayFactor =
-      0.5 + 0.5 * Math.sin((2 * Math.PI * time) / dayCyclePeriod - Math.PI / 2);
+    const dayFactor = getDayFactor(time);
     const skyTopColor = lerpColor(nightSkyTop, daySkyTop, dayFactor);
     const skyBottomColor = lerpColor(nightSkyBottom, daySkyBottom, dayFactor);
     let horizonColor = tonedDownHorizon(
@@ -121,14 +126,14 @@ export function createSky(camera) {
       z: cosPitch * cosYaw,
     };
     const right = {
-      x: Math.sin(camera.yaw - Math.PI / 2),
+      x: Math.sin(camera.yaw + Math.PI / 2),
       y: 0,
-      z: Math.cos(camera.yaw - Math.PI / 2),
+      z: Math.cos(camera.yaw + Math.PI / 2),
     };
     const up = {
-      x: right.y * forward.z - right.z * forward.y,
-      y: right.z * forward.x - right.x * forward.z,
-      z: right.x * forward.y - right.y * forward.x,
+      x: forward.y * right.z - forward.z * right.y,
+      y: forward.z * right.x - forward.x * right.z,
+      z: forward.x * right.y - forward.y * right.x,
     };
     const scale = Math.tan(camera.fov / 2);
 
@@ -266,5 +271,5 @@ export function createSky(camera) {
     }
   }
 
-  return { resize, render };
+  return { resize, render, getDayFactor };
 }

--- a/src/terrain.js
+++ b/src/terrain.js
@@ -1,5 +1,5 @@
 "use strict";
-import { smoothNoise } from "./noise.js";
+import { smoothNoise, lerp } from "./noise.js";
 
 export function createTerrain(seed = Math.floor(Math.random() * 100000)) {
   let W = 0;
@@ -42,7 +42,7 @@ export function createTerrain(seed = Math.floor(Math.random() * 100000)) {
     H = height;
   }
 
-  function draw(ctx, camera) {
+  function draw(ctx, camera, dayFactor = 1) {
     const camX = camera.x;
     const camY = camera.y;
     const camZ = camera.z;
@@ -63,7 +63,13 @@ export function createTerrain(seed = Math.floor(Math.random() * 100000)) {
     const lodFactor = 0.015;
 
     const fogStrength = 0.0025;
-    const fogColor = [155, 185, 215];
+    const fogColorDay = [155, 185, 215];
+    const fogColorNight = [40, 50, 80];
+    const fogColor = [
+      lerp(fogColorNight[0], fogColorDay[0], dayFactor),
+      lerp(fogColorNight[1], fogColorDay[1], dayFactor),
+      lerp(fogColorNight[2], fogColorDay[2], dayFactor),
+    ];
 
     const sinYaw = Math.sin(yaw),
       cosYaw = Math.cos(yaw);
@@ -73,8 +79,8 @@ export function createTerrain(seed = Math.floor(Math.random() * 100000)) {
 
     const sunX = Math.sin(-Math.PI / 3);
     const sunZ = Math.cos(-Math.PI / 3);
-    const ambient = 0.35,
-      lightIntensity = 1.5;
+    const ambient = lerp(0.15, 0.35, dayFactor),
+      lightIntensity = lerp(0.5, 1.5, dayFactor);
     const slopeStep = 3;
 
     for (let z = zNear; z < zFar; ) {
@@ -181,6 +187,8 @@ export function createTerrain(seed = Math.floor(Math.random() * 100000)) {
             const fakeSlope = (hNorm - 0.5) * 0.4;
             finalLight *= 0.8 + fakeSlope;
           }
+
+          finalLight *= lerp(0.2, 1, dayFactor);
 
           r = Math.min(255, r * finalLight);
           g = Math.min(255, g * finalLight);


### PR DESCRIPTION
## Summary
- correct yaw orientation for clouds
- expose day cycle factor from sky
- apply day cycle lighting to terrain and fog
- pass day factor through main loop

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684572ab6720832789ce1aedad5fe7e7