### PR TITLE
Tint terrain with sky color

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 "use strict";
 import { camera, initControls, updateCamera } from "./camera.js";
-import { createSky } from "./sky.js";
+import { createSky, getSkyColor } from "./sky.js";
 import { createTerrain } from "./terrain.js";
 
 const canvas = document.getElementById("canvas");
@@ -33,7 +33,8 @@ function loop() {
 
   sky.render(ctx, time);
   const dayFactor = sky.getDayFactor(time);
-  terrain.draw(ctx, camera, dayFactor);
+  const skyColor = getSkyColor(time);
+  terrain.draw(ctx, camera, dayFactor, skyColor);
 
   requestAnimationFrame(loop);
 }

--- a/src/sky.js
+++ b/src/sky.js
@@ -1,6 +1,41 @@
 "use strict";
 import { fractalNoise, lerpColor, lerp, smoothStep } from "./noise.js";
 
+const dayCyclePeriod = 60;
+
+export function getDayFactor(time) {
+  return (
+    0.5 + 0.5 * Math.sin((2 * Math.PI * time) / dayCyclePeriod - Math.PI / 2)
+  );
+}
+
+export function getSkyColor(time) {
+  const daySkyBottom = { r: 165, g: 200, b: 255 };
+  const nightSkyBottom = { r: 10, g: 10, b: 40 };
+  const sunriseColor = { r: 255, g: 140, b: 70 };
+  const nightHorizonColor = { r: 15, g: 10, b: 30 };
+  const softPurple = { r: 180, g: 150, b: 200 };
+
+  const dayFactor = getDayFactor(time);
+  const skyBottomColor = lerpColor(nightSkyBottom, daySkyBottom, dayFactor);
+  const horizonBase =
+    dayFactor <= 0.33
+      ? lerpColor(nightHorizonColor, sunriseColor, smoothStep(0, 0.33, dayFactor))
+      : dayFactor <= 0.66
+        ? lerpColor(
+            sunriseColor,
+            softPurple,
+            smoothStep(0.33, 0.66, dayFactor),
+          )
+        : lerpColor(
+            softPurple,
+            skyBottomColor,
+            smoothStep(0.66, 1, dayFactor),
+          );
+  const horizonColor = lerpColor(horizonBase, skyBottomColor, 0.4);
+  return horizonColor;
+}
+
 export function createSky(camera) {
   const offRes = 6;
   const offCanvas = document.createElement("canvas");
@@ -17,13 +52,6 @@ export function createSky(camera) {
   const voidFogStart = 1,
     voidFogEnd = 2000;
   const perspectiveExponent = 0.45;
-  const dayCyclePeriod = 60;
-
-  function getDayFactor(time) {
-    return (
-      0.5 + 0.5 * Math.sin((2 * Math.PI * time) / dayCyclePeriod - Math.PI / 2)
-    );
-  }
 
   const daySkyTop = { r: 120, g: 180, b: 240 };
   const daySkyBottom = { r: 165, g: 200, b: 255 };

--- a/src/terrain.js
+++ b/src/terrain.js
@@ -42,7 +42,7 @@ export function createTerrain(seed = Math.floor(Math.random() * 100000)) {
     H = height;
   }
 
-  function draw(ctx, camera, dayFactor = 1) {
+  function draw(ctx, camera, dayFactor = 1, skyColor = { r: 0, g: 0, b: 0 }) {
     const camX = camera.x;
     const camY = camera.y;
     const camZ = camera.z;
@@ -65,10 +65,15 @@ export function createTerrain(seed = Math.floor(Math.random() * 100000)) {
     const fogStrength = 0.0025;
     const fogColorDay = [155, 185, 215];
     const fogColorNight = [40, 50, 80];
-    const fogColor = [
+    const fogColorBase = [
       lerp(fogColorNight[0], fogColorDay[0], dayFactor),
       lerp(fogColorNight[1], fogColorDay[1], dayFactor),
       lerp(fogColorNight[2], fogColorDay[2], dayFactor),
+    ];
+    const fogColor = [
+      lerp(fogColorBase[0], skyColor.r, 0.4),
+      lerp(fogColorBase[1], skyColor.g, 0.4),
+      lerp(fogColorBase[2], skyColor.b, 0.4),
     ];
 
     const sinYaw = Math.sin(yaw),
@@ -193,6 +198,10 @@ export function createTerrain(seed = Math.floor(Math.random() * 100000)) {
           r = Math.min(255, r * finalLight);
           g = Math.min(255, g * finalLight);
           b = Math.min(255, b * finalLight);
+
+          r = lerp(r, skyColor.r, 0.3);
+          g = lerp(g, skyColor.g, 0.3);
+          b = lerp(b, skyColor.b, 0.3);
 
           const yStart = Math.max(0, screenY | 0);
           const yEnd = Math.min(H, yBuffer[xi] | 0);


### PR DESCRIPTION
## Summary
- expose `getSkyColor` to compute the current sky hue
- pass the hue from `main.js` to the terrain renderer
- blend the sky color into fog and terrain lighting

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684575738f0c8327b358103a51cfa0c4